### PR TITLE
fix: removed the autocapitalisation for login/register pages 

### DIFF
--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -184,6 +184,7 @@ const LoginPage = () => {
           autoFocus={!email}
           onChange={(e) => setEmail(e.target.value)}
           helperText={failed && 'Invalid username or password'}
+          inputProps={{ autoCapitalize: 'none' }}
         />
         <TextField
           required
@@ -195,6 +196,7 @@ const LoginPage = () => {
           autoComplete="current-password"
           autoFocus={!!email}
           onChange={(e) => setPassword(e.target.value)}
+          inputProps={{ autoCapitalize: 'none' }}
         />
         {codeEnabled && (
           <TextField

--- a/src/login/RegisterPage.jsx
+++ b/src/login/RegisterPage.jsx
@@ -91,6 +91,7 @@ const RegisterPage = () => {
           autoComplete="name"
           autoFocus
           onChange={(event) => setName(event.target.value)}
+          inputProps={{ autoCapitalize: 'none' }}
         />
         <TextField
           required
@@ -100,6 +101,7 @@ const RegisterPage = () => {
           value={email}
           autoComplete="email"
           onChange={(event) => setEmail(event.target.value)}
+          inputProps={{ autoCapitalize: 'none' }}
         />
         <TextField
           required
@@ -109,6 +111,7 @@ const RegisterPage = () => {
           type="password"
           autoComplete="current-password"
           onChange={(event) => setPassword(event.target.value)}
+          inputProps={{ autoCapitalize: 'none' }}
         />
         {totpForce && (
           <TextField


### PR DESCRIPTION
NOTE: seems to be android specific issue

Changes
- Added an input props to remove autocapitalisation on Login and Register page